### PR TITLE
use slf4j-api instead of slf4j-nop

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
 
 		<dependency>
 			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-nop</artifactId>
+			<artifactId>slf4j-api</artifactId>
 			<version>${sl4j.version}</version>
 		</dependency>
 


### PR DESCRIPTION
ziplet's transitive slf4j-nop dependency can nuke a project's logging entirely.
Make ziplet write to the slf4j-api without bringing along an implementation.
