### PR TITLE
Fixing the ETag behaviour

### DIFF
--- a/src/main/java/com/github/ziplet/filter/compression/CompressingHttpServletResponse.java
+++ b/src/main/java/com/github/ziplet/filter/compression/CompressingHttpServletResponse.java
@@ -199,7 +199,7 @@ final class CompressingHttpServletResponse extends HttpServletResponseWrapper {
 
     private void setETagHeader() {
         if (savedETag != null) {
-            if (compressing) {
+            if (compressing && !savedETag.startsWith("W")) {
                 httpResponse.setHeader(ETAG_HEADER, savedETag + '-' + compressedContentEncoding);
             } else {
                 httpResponse.setHeader(ETAG_HEADER, savedETag);


### PR DESCRIPTION
“Weak Etag values of two representations of the same resources might be semantically equivalent, but not byte-for-byte identical.”
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag#Directives