### PR TITLE
google-java-format should not be a dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
 			<groupId>com.google.googlejavaformat</groupId>
 			<artifactId>google-java-format</artifactId>
 			<version>1.4</version>
+			<scope>provided</scope>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
there is no reason why this has to be included in
application where the only need is to use compression
code.