### PR TITLE
Migrate from JavaEE to JakartaEE

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,10 @@ ziplet
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.github.ziplet/ziplet/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.github.ziplet/ziplet)
 [![Build Status](https://travis-ci.org/ziplet/ziplet.svg?branch=master)](https://travis-ci.org/ziplet/ziplet)
 
-This filter can, based on HTTP headers in a HttpServletRequest, compress data written to the HttpServletResponse, or decompress data read from the request. When supported by the client browser, this can potentially greatly reduce the number of bytes written across the network from and to the client. As a Filter, this class can also be easily added to any J2EE 1.3+ web application.
+This filter can, based on HTTP headers in a HttpServletRequest, compress data written to the HttpServletResponse, or
+decompress data read from the request. When supported by the client browser, this can potentially greatly reduce the
+number of bytes written across the network from and to the client. As a Filter, this class can also be easily added to
+any JakartaEE web application.
 
 
 Features
@@ -49,29 +52,53 @@ Configuration
 
 CompressingFilter supports the following parameters:
 
-**debug** (optional): if set to "true", additional debug information will be written to the servlet log. Defaults to false.
+**debug** (optional): if set to "true", additional debug information will be written to the servlet log. Defaults to
+false.
 
-**compressionThreshold** (optional): sets the size of the smallest response that will be compressed, in bytes. That is, if less than compressionThreshold bytes are written to the response, it will not be compressed and the response will go to the client unmodified. If 0, compression always begins immediately. Defaults to 1024.
+**compressionThreshold** (optional): sets the size of the smallest response that will be compressed, in bytes. That is,
+if less than compressionThreshold bytes are written to the response, it will not be compressed and the response will go
+to the client unmodified. If 0, compression always begins immediately. Defaults to 1024.
 
-**compressionLevel** (optional): sets the compression level used for response gzip/deflate compression, from 1 (fastest compression, less CPU) to 9 (best compression, more CPU), or -1 (platform default, currently equivalent to 6). Defaults to -1.
+**compressionLevel** (optional): sets the compression level used for response gzip/deflate compression, from 1 (fastest
+compression, less CPU) to 9 (best compression, more CPU), or -1 (platform default, currently equivalent to 6). Defaults
+to -1.
 
-**statsEnabled** (optional): enables collection of statistics. See CompressingFilterStats. Defaults to false. Don't use this in high traffic environments!
+**statsEnabled** (optional): enables collection of statistics. See CompressingFilterStats. Defaults to false. Don't use
+this in high traffic environments!
 
-**includeContentTypes** (optional): if specified, this is treated as a comma-separated list of content types (e.g. text/html,text/xml). The filter will attempt to only compress responses which specify one of these values as its content type, for example via ServletResponse.setContentType(String). Note that the filter does not know the response content type at the time it is applied, and so must apply itself and later attempt to disable compression when content type has been set. This will fail if the response has already been committed. Also note that this parameter cannot be specified if excludeContentTypes is too.
+**includeContentTypes** (optional): if specified, this is treated as a comma-separated list of content types (e.g.
+text/html,text/xml). The filter will attempt to only compress responses which specify one of these values as its content
+type, for example via ServletResponse.setContentType(String). Note that the filter does not know the response content
+type at the time it is applied, and so must apply itself and later attempt to disable compression when content type has
+been set. This will fail if the response has already been committed. Also note that this parameter cannot be specified
+if excludeContentTypes is too.
 
-**excludeContentTypes** (optional): same as above, but specifies a list of content types to not compress. Everything else will be compressed. However note that any content type that indicates a compressed format (e.g. application/gzip, application/x-compress) will not be compressed in any event.
+**excludeContentTypes** (optional): same as above, but specifies a list of content types to not compress. Everything
+else will be compressed. However note that any content type that indicates a compressed format (e.g. application/gzip,
+application/x-compress) will not be compressed in any event.
 
-**includePathPatterns** (optional): if specified, this is treated as a comma-separated list of regular expressions (of the type accepted by Pattern) which match exactly those paths which should be compressed by this filter. Anything else will not be compressed. One can also merely apply the filter to a subset of all URIs served by the web application using standard filter-mapping elements in web.xml; this element provides more fine-grained control for when that mechanism is insufficient. "Paths" here means values returned by HttpServletRequest.getRequestURI(). Note that the regex must match the filename exactly; pattern "static" does not match everything containing the string "static. Use ".*static.*" for that, for example. This cannot be specified if excludeFileTypes is too.
+**includePathPatterns** (optional): if specified, this is treated as a comma-separated list of regular expressions (of
+the type accepted by Pattern) which match exactly those paths which should be compressed by this filter. Anything else
+will not be compressed. One can also merely apply the filter to a subset of all URIs served by the web application using
+standard filter-mapping elements in web.xml; this element provides more fine-grained control for when that mechanism is
+insufficient. "Paths" here means values returned by HttpServletRequest.getRequestURI(). Note that the regex must match
+the filename exactly; pattern "static" does not match everything containing the string "static. Use ".*static.*" for
+that, for example. This cannot be specified if excludeFileTypes is too.
 
-**excludePathPatterns** (optional): same as above, but specifies a list of patterns which match paths that should not be compressed. Everything else will be compressed.
+**excludePathPatterns** (optional): same as above, but specifies a list of patterns which match paths that should not be
+compressed. Everything else will be compressed.
 
-**includeUserAgentPatterns** (optional): Like includePathPatterns. Only requests with User-Agent headers whose value matches one of these regular expressions will be compressed. Can't be specified if excludeUserAgentPatterns is too.
+**includeUserAgentPatterns** (optional): Like includePathPatterns. Only requests with User-Agent headers whose value
+matches one of these regular expressions will be compressed. Can't be specified if excludeUserAgentPatterns is too.
 
-**excludeUserAgentPatterns** (optional): as above, requests whose User-Agent header matches one of these patterns will not be compressed.
+**excludeUserAgentPatterns** (optional): as above, requests whose User-Agent header matches one of these patterns will
+not be compressed.
 
-**noVaryHeaderPatterns** (optional): Like includeUserAgentPatterns. Requests with User-Agent headers whose value matches one of these regular expressions result in a response that does not contain the Vary-header Since version 1.8
+**noVaryHeaderPatterns** (optional): Like includeUserAgentPatterns. Requests with User-Agent headers whose value matches
+one of these regular expressions result in a response that does not contain the Vary-header Since version 1.8
 
 These values are configured in web.xml as well with init-param elements:
+
 ```xml
     <filter>
         <filter-name>CompressingFilter</filter-name>
@@ -82,12 +109,14 @@ These values are configured in web.xml as well with init-param elements:
         </init-param>
     </filter>
 ```
+
 Supported compression algorithms
 --------------------------------
 
 Response
 
-This filter supports the following compression algorithms when compressing data to the repsonse, as specified in the "Accept-Encoding" HTTP request header:
+This filter supports the following compression algorithms when compressing data to the repsonse, as specified in the "
+Accept-Encoding" HTTP request header:
 
 *gzip
 *x-gzip
@@ -97,7 +126,8 @@ This filter supports the following compression algorithms when compressing data 
 *identity (that is, no compression)
 *Request
 
-This filter supports the following compression algorithms when decompressing data from the request body, as specified in the "Content-Encoding" HTTP request header:
+This filter supports the following compression algorithms when decompressing data from the request body, as specified in
+the "Content-Encoding" HTTP request header:
 
 *gzip
 *x-gzip
@@ -107,22 +137,31 @@ This filter supports the following compression algorithms when decompressing dat
 *identity
 *Controlling runtime behavior
 
-An application may force the encoding / compression used by setting an "Accept-Encoding" value into the request as an attribute under the key FORCE_ENCODING_KEY. Obviously this has to be set upstream from the filter, not downstream.
+An application may force the encoding / compression used by setting an "Accept-Encoding" value into the request as an
+attribute under the key FORCE_ENCODING_KEY. Obviously this has to be set upstream from the filter, not downstream.
 
 Caveats and Notes
 -----------------
 
-The filter requires Java 5 and J2EE 1.4 or better.
+The filter requires Java 8 and JakartaEE.
 
-Note that if this filter decides that it should try to compress the response, it will close the response (whether or not it ends up compressing the response). No more can be written to the response after this filter has been applied; this should never be necessary anyway. Put this filter ahead of any filters that might try to write to the response, since presumably you want this content compressed too anyway.
+Note that if this filter decides that it should try to compress the response, it will close the response (whether or not
+it ends up compressing the response). No more can be written to the response after this filter has been applied; this
+should never be necessary anyway. Put this filter ahead of any filters that might try to write to the response, since
+presumably you want this content compressed too anyway.
 
-If a OutputStream.flush() occurs before the filter has decided whether to compress or not, it will be forced into compression mode.
+If a OutputStream.flush() occurs before the filter has decided whether to compress or not, it will be forced into
+compression mode.
 
 The filter will not compress if the response sets Cache-Control: no-transform header in the response.
 
-The filter attempts to modify the ETag response header, if present, when compressing. This is because the compressed response must be considered a separate entity by caches. It simply appends, for example, "-gzip" to the ETag header value when compressing with gzip. This is not guaranteed to work in all containers, in the sense that some containers may not properly associated this ETag with the compressed content and simply return the response again.
+The filter attempts to modify the ETag response header, if present, when compressing. This is because the compressed
+response must be considered a separate entity by caches. It simply appends, for example, "-gzip" to the ETag header
+value when compressing with gzip. This is not guaranteed to work in all containers, in the sense that some containers
+may not properly associated this ETag with the compressed content and simply return the response again.
 
-The filter normally sets the Vary response header to indicate that a different response may be returned based on the Accept-Encoding header of the request. This can be configured in the web.xml.
+The filter normally sets the Vary response header to indicate that a different response may be returned based on the
+Accept-Encoding header of the request. This can be configured in the web.xml.
 
 License
 -------

--- a/pom.xml
+++ b/pom.xml
@@ -1,236 +1,247 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<groupId>com.github.ziplet</groupId>
-	<artifactId>ziplet</artifactId>
-	<version>2.4.2-SNAPSHOT</version>
-	<packaging>jar</packaging>
-	<name>ziplet</name>
-	<description>This filter can, based on HTTP headers in a HttpServletRequest, compress data written to the
-		HttpServletResponse, or decompress data read from the request. When supported by the client browser,
-		this can potentially greatly reduce the number of bytes written across the network from and to the client.
-		As a Filter, this class can also be easily added to any J2EE 1.3+ web application.
-	</description>
-	<url>https://github.com/ziplet/ziplet</url>
-	<licenses>
-		<license>
-			<name>The Apache Software License, Version 2.0</name>
-			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-			<distribution>repo</distribution>
-		</license>
-	</licenses>
-	<scm>
-		<connection>scm:git:git@github.com:ziplet/ziplet.git</connection>
-		<developerConnection>scm:git:git@github.com:ziplet/ziplet.git</developerConnection>
-		<url>git@github.com:ziplet/ziplet.git</url>
-	  <tag>HEAD</tag>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.github.ziplet</groupId>
+  <artifactId>ziplet</artifactId>
+  <version>2.4.2-SNAPSHOT</version>
+  <packaging>jar</packaging>
+  <name>ziplet</name>
+  <description>This filter can, based on HTTP headers in a HttpServletRequest, compress data written to the
+    HttpServletResponse, or decompress data read from the request. When supported by the client browser,
+    this can potentially greatly reduce the number of bytes written across the network from and to the client.
+    As a Filter, this class can also be easily added to any J2EE 1.3+ web application.
+  </description>
+  <url>https://github.com/ziplet/ziplet</url>
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+  <scm>
+    <connection>scm:git:git@github.com:ziplet/ziplet.git</connection>
+    <developerConnection>scm:git:git@github.com:ziplet/ziplet.git</developerConnection>
+    <url>git@github.com:ziplet/ziplet.git</url>
+    <tag>HEAD</tag>
   </scm>
-	<developers>
-		<developer>
-			<id>fgaule</id>
-			<name>Federico Gaule</name>
-			<email>federico.gaule@gmail.com</email>
-			<timezone>-3</timezone>
-			<organization>Despegar</organization>
-			<organizationUrl>http://www.despegar.com</organizationUrl>
-		</developer>
-		<developer>
-			<id>fededonna</id>
-			<name>Federico Donnarumma</name>
-			<email>fdonnarumma@gmail.com</email>
-			<timezone>-3</timezone>
-			<organization>Mulesoft</organization>
-			<organizationUrl>https://www.mulesoft.com/</organizationUrl>
-		</developer>
-	</developers>
+  <developers>
+    <developer>
+      <id>fgaule</id>
+      <name>Federico Gaule</name>
+      <email>federico.gaule@gmail.com</email>
+      <timezone>-3</timezone>
+      <organization>Despegar</organization>
+      <organizationUrl>http://www.despegar.com</organizationUrl>
+    </developer>
+    <developer>
+      <id>fededonna</id>
+      <name>Federico Donnarumma</name>
+      <email>fdonnarumma@gmail.com</email>
+      <timezone>-3</timezone>
+      <organization>Mulesoft</organization>
+      <organizationUrl>https://www.mulesoft.com/</organizationUrl>
+    </developer>
+  </developers>
 
-	<properties>
-		<sl4j.version>1.7.6</sl4j.version>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-	</properties>
+  <properties>
+    <sl4j.version>1.7.6</sl4j.version>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <java.version>17</java.version>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
 
-	<dependencies>
-		<dependency>
-			<groupId>com.google.googlejavaformat</groupId>
-			<artifactId>google-java-format</artifactId>
-			<version>1.4</version>
-			<scope>provided</scope>
-		</dependency>
+  <dependencies>
+    <dependency>
+      <groupId>com.google.googlejavaformat</groupId>
+      <artifactId>google-java-format</artifactId>
+      <version>1.4</version>
+      <scope>provided</scope>
+    </dependency>
 
-		<dependency>
-			<groupId>javax.servlet</groupId>
-			<artifactId>servlet-api</artifactId>
-			<version>2.5</version>
-			<scope>provided</scope>
-		</dependency>
+    <dependency>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>6.0.0</version>
+      <scope>provided</scope>
+    </dependency>
 
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-api</artifactId>
-			<version>${sl4j.version}</version>
-		</dependency>
-		<!--TEST-->
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.8.1</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>com.mockrunner</groupId>
-			<artifactId>mockrunner-servlet</artifactId>
-			<version>1.0.0</version>
-			<scope>test</scope>
-		</dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${sl4j.version}</version>
+    </dependency>
+    <!--TEST-->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.8.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-test</artifactId>
+      <version>6.0.9</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-web</artifactId>
+      <version>6.0.9</version>
+      <scope>test</scope>
+    </dependency>
 
-	</dependencies>
+  </dependencies>
 
 
-	<!-- Maven Central -->
-	<distributionManagement>
-		<snapshotRepository>
-			<id>ossrh</id>
-			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
-		</snapshotRepository>
-	</distributionManagement>
+  <!-- Maven Central -->
+  <distributionManagement>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+  </distributionManagement>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.1</version>
-				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
-				</configuration>
-			</plugin>
-			<!-- Make a jar and put the sources in the jar -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-source-plugin</artifactId>
-				<version>2.4</version>
-				<executions>
-					<execution>
-						<id>attach-sources</id>
-						<phase>prepare-package</phase>
-						<goals>
-							<goal>jar-no-fork</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.9.1</version>
-				<configuration>
-					<maxmemory>2048m</maxmemory>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.16</version>
-				<dependencies>
-					<dependency>
-						<groupId>org.apache.maven.surefire</groupId>
-						<artifactId>surefire-junit47</artifactId>
-						<version>2.16</version>
-					</dependency>
-				</dependencies>
-			</plugin>
-			<plugin>
-				<groupId>org.jasig.maven</groupId>
-				<artifactId>maven-notice-plugin</artifactId>
-				<version>1.0.5</version>
-				<configuration>
-					<noticeTemplate>src/main/resources/NOTICE.template</noticeTemplate>
-					<licenseMapping>
-						<param>src/main/resources/license-mappings.xml</param>
-					</licenseMapping>
-				</configuration>
-			</plugin>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <version>3.3.1</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.11.0</version>
+      </plugin>
+      <!-- Make a jar and put the sources in the jar -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>3.3.0</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>jar-no-fork</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>2.9.1</version>
+        <configuration>
+          <maxmemory>2048m</maxmemory>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.1.2</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.maven.surefire</groupId>
+            <artifactId>surefire-junit47</artifactId>
+            <version>3.1.2</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+      <plugin>
+        <groupId>org.jasig.maven</groupId>
+        <artifactId>maven-notice-plugin</artifactId>
+        <version>1.0.5</version>
+        <configuration>
+          <noticeTemplate>src/main/resources/NOTICE.template</noticeTemplate>
+          <licenseMapping>
+            <param>src/main/resources/license-mappings.xml</param>
+          </licenseMapping>
+        </configuration>
+      </plugin>
 
-			<!-- Maven central staging -->
-			<plugin>
-				<groupId>org.sonatype.plugins</groupId>
-				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.7</version>
-				<extensions>true</extensions>
-				<configuration>
-					<serverId>ossrh</serverId>
-					<nexusUrl>https://oss.sonatype.org/</nexusUrl>
-					<autoReleaseAfterClose>true</autoReleaseAfterClose>
-				</configuration>
-			</plugin>
+      <!-- Maven central staging -->
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <version>1.6.7</version>
+        <extensions>true</extensions>
+        <configuration>
+          <serverId>ossrh</serverId>
+          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+          <autoReleaseAfterClose>true</autoReleaseAfterClose>
+        </configuration>
+      </plugin>
 
-			<!-- Release plugin -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-release-plugin</artifactId>
-				<version>2.5.3</version>
-				<configuration>
-					<autoVersionSubmodules>true</autoVersionSubmodules>
-					<useReleaseProfile>false</useReleaseProfile>
-					<releaseProfiles>release</releaseProfiles>
-					<goals>deploy</goals>
-				</configuration>
-			</plugin>
+      <!-- Release plugin -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-release-plugin</artifactId>
+        <version>2.5.3</version>
+        <configuration>
+          <autoVersionSubmodules>true</autoVersionSubmodules>
+          <useReleaseProfile>false</useReleaseProfile>
+          <releaseProfiles>release</releaseProfiles>
+          <goals>deploy</goals>
+        </configuration>
+      </plugin>
 
-		</plugins>
-	</build>
+    </plugins>
+  </build>
 
-	<profiles>
-		<profile>
-			<id>release</id>
-			<build>
-				<plugins>
-					<!-- GPG Signed release -->
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-gpg-plugin</artifactId>
-						<version>1.5</version>
-						<executions>
-							<execution>
-								<id>sign-artifacts</id>
-								<phase>verify</phase>
-								<goals>
-									<goal>sign</goal>
-								</goals>
-							</execution>
-						</executions>
-					</plugin>
-					<!-- Javadoc & Sources -->
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-source-plugin</artifactId>
-						<version>2.2.1</version>
-						<executions>
-							<execution>
-								<id>attach-sources</id>
-								<goals>
-									<goal>jar-no-fork</goal>
-								</goals>
-							</execution>
-						</executions>
-					</plugin>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-javadoc-plugin</artifactId>
-						<version>2.9.1</version>
-						<executions>
-							<execution>
-								<id>attach-javadocs</id>
-								<goals>
-									<goal>jar</goal>
-								</goals>
-							</execution>
-						</executions>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-	</profiles>
+  <profiles>
+    <profile>
+      <id>release</id>
+      <build>
+        <plugins>
+          <!-- GPG Signed release -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>1.5</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <!-- Javadoc & Sources -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>3.3.0</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>2.9.1</version>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
 </project>

--- a/src/main/java/com/github/ziplet/filter/compression/CompressedHttpServletRequest.java
+++ b/src/main/java/com/github/ziplet/filter/compression/CompressedHttpServletRequest.java
@@ -15,16 +15,17 @@
  */
 package com.github.ziplet.filter.compression;
 
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Enumeration;
-import javax.servlet.ServletInputStream;
-import javax.servlet.ServletRequest;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletRequestWrapper;
 
 /**
  * <p>Implementation of {@link HttpServletRequest} which can decompress request bodies that have
@@ -44,8 +45,8 @@ final class CompressedHttpServletRequest extends HttpServletRequestWrapper {
     private boolean isGetReaderCalled;
 
     CompressedHttpServletRequest(HttpServletRequest httpRequest,
-        CompressingStreamFactory compressingStreamFactory,
-        CompressingFilterContext context) {
+                                 CompressingStreamFactory compressingStreamFactory,
+                                 CompressingFilterContext context) {
         super(httpRequest);
         this.httpRequest = httpRequest;
         this.compressingStreamFactory = compressingStreamFactory;
@@ -58,7 +59,7 @@ final class CompressedHttpServletRequest extends HttpServletRequestWrapper {
         // Filter Content-Encoding since we're handing decompression ourselves;
         // filter Accept-Encoding so that downstream services don't try to compress too
         return CompressingHttpServletResponse.CONTENT_ENCODING_HEADER.equalsIgnoreCase(headerName)
-            || CompressingHttpServletResponse.ACCEPT_ENCODING_HEADER.equalsIgnoreCase(headerName);
+                || CompressingHttpServletResponse.ACCEPT_ENCODING_HEADER.equalsIgnoreCase(headerName);
     }
 
     @Override
@@ -78,8 +79,8 @@ final class CompressedHttpServletRequest extends HttpServletRequestWrapper {
         isGetReaderCalled = true;
         if (bufferedReader == null) {
             bufferedReader = new BufferedReader(
-                new InputStreamReader(getCompressingServletInputStream(),
-                    getCharacterEncoding()));
+                    new InputStreamReader(getCompressingServletInputStream(),
+                            getCharacterEncoding()));
         }
         return bufferedReader;
     }
@@ -87,8 +88,8 @@ final class CompressedHttpServletRequest extends HttpServletRequestWrapper {
     private CompressingServletInputStream getCompressingServletInputStream() throws IOException {
         if (compressedSIS == null) {
             compressedSIS = new CompressingServletInputStream(httpRequest.getInputStream(),
-                compressingStreamFactory,
-                context);
+                    compressingStreamFactory,
+                    context);
         }
         return compressedSIS;
     }
@@ -99,12 +100,12 @@ final class CompressedHttpServletRequest extends HttpServletRequestWrapper {
     }
 
     @Override
-    public Enumeration<?> getHeaders(String header) {
-        Enumeration<?> original = super.getHeaders(header);
+    public Enumeration<String> getHeaders(String header) {
+        Enumeration<String> original = super.getHeaders(header);
         if (original == null) {
             return null; // match container's behavior exactly in this case
         }
-        return isFilteredHeader(header) ? EmptyEnumeration.getInstance() : original;
+        return isFilteredHeader(header) ? (Enumeration<String>) EmptyEnumeration.getInstance() : original;
     }
 
     @Override
@@ -118,8 +119,8 @@ final class CompressedHttpServletRequest extends HttpServletRequestWrapper {
     }
 
     @Override
-    public Enumeration<?> getHeaderNames() {
-        Enumeration<?> original = super.getHeaderNames();
+    public Enumeration<String> getHeaderNames() {
+        Enumeration<String> original = super.getHeaderNames();
         if (original == null) {
             return null; // match container's behavior exactly in this case
         }

--- a/src/main/java/com/github/ziplet/filter/compression/CompressingFilter.java
+++ b/src/main/java/com/github/ziplet/filter/compression/CompressingFilter.java
@@ -16,18 +16,19 @@
 package com.github.ziplet.filter.compression;
 
 import com.github.ziplet.filter.compression.statistics.CompressingFilterStats;
-import java.io.IOException;
-import java.util.regex.Pattern;
-import javax.servlet.Filter;
-import javax.servlet.FilterChain;
-import javax.servlet.FilterConfig;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.regex.Pattern;
 
 /**
  * <p>This filter can, based on HTTP headers in a {@link HttpServletRequest}, compress data written
@@ -237,8 +238,8 @@ public final class CompressingFilter implements Filter {
     }
 
     public void doFilter(ServletRequest request,
-        ServletResponse response,
-        FilterChain chain) throws IOException, ServletException {
+                         ServletResponse response,
+                         FilterChain chain) throws IOException, ServletException {
 
         ServletRequest chainRequest = getRequest(request);
         ServletResponse chainResponse = getResponse(request, response);
@@ -299,7 +300,7 @@ public final class CompressingFilter implements Filter {
 
         HttpServletRequest httpRequest = (HttpServletRequest) request;
         String contentEncoding = httpRequest
-            .getHeader(CompressingHttpServletResponse.CONTENT_ENCODING_HEADER);
+                .getHeader(CompressingHttpServletResponse.CONTENT_ENCODING_HEADER);
         if (contentEncoding == null) {
             LOGGER.debug("Request is not compressed, so not decompressing");
             return null;
@@ -311,19 +312,19 @@ public final class CompressingFilter implements Filter {
         }
 
         return new CompressedHttpServletRequest(httpRequest,
-            CompressingStreamFactory.getFactoryForContentEncoding(contentEncoding),
-            context);
+                CompressingStreamFactory.getFactoryForContentEncoding(contentEncoding),
+                context);
     }
 
     private ServletResponse getResponse(ServletRequest request,
-        ServletResponse response) {
+                                        ServletResponse response) {
         if (response.isCommitted() || request.getAttribute(ALREADY_APPLIED_KEY) != null) {
             LOGGER.debug("Response committed or filter has already been applied");
             return null;
         }
 
         if (!(request instanceof HttpServletRequest)
-            || !(response instanceof HttpServletResponse)) {
+                || !(response instanceof HttpServletResponse)) {
             LOGGER.debug("Can't compress non-HTTP request, response");
             return null;
         }
@@ -363,16 +364,16 @@ public final class CompressingFilter implements Filter {
 
         if (LOGGER.isDebugEnabled()) {
             LOGGER
-                .debug("Compression supported; using content encoding '" + contentEncoding + '\'');
+                    .debug("Compression supported; using content encoding '" + contentEncoding + '\'');
         }
 
         CompressingStreamFactory compressingStreamFactory =
-            CompressingStreamFactory.getFactoryForContentEncoding(contentEncoding);
+                CompressingStreamFactory.getFactoryForContentEncoding(contentEncoding);
 
         return new CompressingHttpServletResponse(httpResponse,
-            compressingStreamFactory,
-            contentEncoding,
-            context);
+                compressingStreamFactory,
+                contentEncoding,
+                context);
     }
 
     /**
@@ -398,14 +399,14 @@ public final class CompressingFilter implements Filter {
         if (sendVaryHeader(userAgent)) {
             if (LOGGER.isDebugEnabled()) {
                 LOGGER.debug("Setting Vary Header because the response *could be compressed*. "
-                    + VARY_HEADER + " : " + CompressingHttpServletResponse.ACCEPT_ENCODING_HEADER);
+                        + VARY_HEADER + " : " + CompressingHttpServletResponse.ACCEPT_ENCODING_HEADER);
             }
             httpResponse
-                .addHeader(VARY_HEADER, CompressingHttpServletResponse.ACCEPT_ENCODING_HEADER);
+                    .addHeader(VARY_HEADER, CompressingHttpServletResponse.ACCEPT_ENCODING_HEADER);
         } else {
             if (LOGGER.isDebugEnabled()) {
                 LOGGER
-                    .debug("Vary header not set, because user agent should not receive the header");
+                        .debug("Vary header not set, because user agent should not receive the header");
             }
         }
     }

--- a/src/main/java/com/github/ziplet/filter/compression/CompressingFilterContext.java
+++ b/src/main/java/com/github/ziplet/filter/compression/CompressingFilterContext.java
@@ -18,17 +18,18 @@ package com.github.ziplet.filter.compression;
 import com.github.ziplet.filter.compression.statistics.CompressingFilterEmptyStats;
 import com.github.ziplet.filter.compression.statistics.CompressingFilterStats;
 import com.github.ziplet.filter.compression.statistics.CompressingFilterStatsImpl;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.regex.Pattern;
 import java.util.zip.Deflater;
-import javax.servlet.FilterConfig;
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Encapsulates the {@link CompressingFilter} environment, including configuration and runtime
@@ -60,7 +61,7 @@ final class CompressingFilterContext {
     private CompressingFilterStats stats;
 
     CompressingFilterContext(FilterConfig filterConfig, CompressingFilterStats stats)
-        throws ServletException {
+            throws ServletException {
         this(filterConfig);
         this.setCompressingFilterStats(stats);
     }
@@ -106,7 +107,7 @@ final class CompressingFilterContext {
         String excludeContentTypesString = filterConfig.getInitParameter("excludeContentTypes");
         if (includeContentTypesString != null && excludeContentTypesString != null) {
             throw new IllegalArgumentException(
-                "Can't specify both includeContentTypes and excludeContentTypes");
+                    "Can't specify both includeContentTypes and excludeContentTypes");
         }
 
         if (includeContentTypesString == null) {
@@ -119,14 +120,14 @@ final class CompressingFilterContext {
 
         if (!contentTypes.isEmpty()) {
             LOGGER.debug("Filter will " + (includeContentTypes ? "include" : "exclude")
-                + " only these content types: " + contentTypes);
+                    + " only these content types: " + contentTypes);
         }
 
         String includePathPatternsString = filterConfig.getInitParameter("includePathPatterns");
         String excludePathPatternsString = filterConfig.getInitParameter("excludePathPatterns");
         if (includePathPatternsString != null && excludePathPatternsString != null) {
             throw new IllegalArgumentException(
-                "Can't specify both includePathPatterns and excludePathPatterns");
+                    "Can't specify both includePathPatterns and excludePathPatterns");
         }
 
         if (includePathPatternsString == null) {
@@ -139,16 +140,16 @@ final class CompressingFilterContext {
 
         if (!pathPatterns.isEmpty() && LOGGER.isDebugEnabled()) {
             LOGGER.debug("Filter will " + (includePathPatterns ? "include" : "exclude")
-                + " only these file patterns: " + pathPatterns);
+                    + " only these file patterns: " + pathPatterns);
         }
 
         String includeUserAgentPatternsString = filterConfig
-            .getInitParameter("includeUserAgentPatterns");
+                .getInitParameter("includeUserAgentPatterns");
         String excludeUserAgentPatternsString = filterConfig
-            .getInitParameter("excludeUserAgentPatterns");
+                .getInitParameter("excludeUserAgentPatterns");
         if (includeUserAgentPatternsString != null && excludeUserAgentPatternsString != null) {
             throw new IllegalArgumentException(
-                "Can't specify both includeUserAgentPatterns and excludeUserAgentPatterns");
+                    "Can't specify both includeUserAgentPatterns and excludeUserAgentPatterns");
         }
 
         if (includeUserAgentPatternsString == null) {
@@ -161,7 +162,7 @@ final class CompressingFilterContext {
 
         if (!userAgentPatterns.isEmpty() && LOGGER.isDebugEnabled()) {
             LOGGER.debug("Filter will " + (includeUserAgentPatterns ? "include" : "exclude")
-                + " only these User-Agent patterns: " + userAgentPatterns);
+                    + " only these User-Agent patterns: " + userAgentPatterns);
         }
 
     }
@@ -171,7 +172,7 @@ final class CompressingFilterContext {
     }
 
     private static int readCompressionThresholdValue(FilterConfig filterConfig)
-        throws ServletException {
+            throws ServletException {
         String compressionThresholdString = filterConfig.getInitParameter("compressionThreshold");
         int value;
         if (compressionThresholdString != null) {
@@ -179,8 +180,8 @@ final class CompressingFilterContext {
                 value = Integer.parseInt(compressionThresholdString);
             } catch (NumberFormatException nfe) {
                 throw new ServletException(
-                    "Invalid compression threshold: " + compressionThresholdString,
-                    nfe);
+                        "Invalid compression threshold: " + compressionThresholdString,
+                        nfe);
             }
             if (value < 0) {
                 throw new ServletException("Compression threshold cannot be negative");
@@ -192,7 +193,7 @@ final class CompressingFilterContext {
     }
 
     private static int readCompressionLevelValue(FilterConfig filterConfig)
-        throws ServletException {
+            throws ServletException {
         String compressionLevelString = filterConfig.getInitParameter("compressionLevel");
         int value;
         if (compressionLevelString != null) {
@@ -200,7 +201,7 @@ final class CompressingFilterContext {
                 value = Integer.parseInt(compressionLevelString);
             } catch (NumberFormatException nfe) {
                 throw new ServletException("Invalid compression level: " + compressionLevelString,
-                    nfe);
+                        nfe);
             }
             if (value == -1) {
                 value = DEFAULT_COMPRESSION_LEVEL;
@@ -208,7 +209,7 @@ final class CompressingFilterContext {
                 throw new ServletException("Compression level cannot be negative, unless it is -1");
             } else if (value > Deflater.BEST_COMPRESSION) {
                 throw new ServletException(
-                    "Compression level cannot be greater than " + Deflater.BEST_COMPRESSION);
+                        "Compression level cannot be greater than " + Deflater.BEST_COMPRESSION);
             }
         } else {
             value = DEFAULT_COMPRESSION_LEVEL;

--- a/src/main/java/com/github/ziplet/filter/compression/CompressingHttpServletResponse.java
+++ b/src/main/java/com/github/ziplet/filter/compression/CompressingHttpServletResponse.java
@@ -15,14 +15,15 @@
  */
 package com.github.ziplet.filter.compression;
 
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponseWrapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
-import javax.servlet.ServletOutputStream;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpServletResponseWrapper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Implementation of {@link HttpServletResponse} which will optionally compress data written to the
@@ -35,14 +36,14 @@ final class CompressingHttpServletResponse extends HttpServletResponseWrapper {
     static final String ACCEPT_ENCODING_HEADER = "Accept-Encoding";
     static final String CONTENT_ENCODING_HEADER = "Content-Encoding";
     private static final Logger LOGGER = LoggerFactory
-        .getLogger(CompressingHttpServletResponse.class);
+            .getLogger(CompressingHttpServletResponse.class);
     private static final String CACHE_CONTROL_HEADER = "Cache-Control";
     private static final String CONTENT_LENGTH_HEADER = "Content-Length";
     private static final String CONTENT_TYPE_HEADER = "Content-Type";
     private static final String ETAG_HEADER = "ETag";
     private static final String X_COMPRESSED_BY_HEADER = "X-Compressed-By";
     private static final String[] UNALLOWED_HEADERS = {CACHE_CONTROL_HEADER, CONTENT_LENGTH_HEADER,
-        CONTENT_ENCODING_HEADER, ETAG_HEADER, X_COMPRESSED_BY_HEADER};
+            CONTENT_ENCODING_HEADER, ETAG_HEADER, X_COMPRESSED_BY_HEADER};
     private static final String COMPRESSED_BY_VALUE = CompressingFilter.VERSION_STRING;
     private final HttpServletResponse httpResponse;
     private final CompressingFilterContext context;
@@ -61,9 +62,9 @@ final class CompressingHttpServletResponse extends HttpServletResponseWrapper {
     private boolean noTransformSet;
 
     CompressingHttpServletResponse(HttpServletResponse httpResponse,
-        CompressingStreamFactory compressingStreamFactory,
-        String contentEncoding,
-        CompressingFilterContext context) {
+                                   CompressingStreamFactory compressingStreamFactory,
+                                   String contentEncoding,
+                                   CompressingFilterContext context) {
         super(httpResponse);
         this.httpResponse = httpResponse;
         this.compressedContentEncoding = contentEncoding;
@@ -111,9 +112,9 @@ final class CompressingHttpServletResponse extends HttpServletResponseWrapper {
         isGetWriterCalled = true;
         if (printWriter == null) {
             printWriter = new PrintWriter(
-                new OutputStreamWriter(getCompressingServletOutputStream(),
-                    getCharacterEncoding()),
-                true);
+                    new OutputStreamWriter(getCompressingServletOutputStream(),
+                            getCharacterEncoding()),
+                    true);
         }
         return printWriter;
     }
@@ -224,7 +225,7 @@ final class CompressingHttpServletResponse extends HttpServletResponseWrapper {
     private void setETagHeader() {
         if (savedETag != null) {
             if (compressing && !savedETag.startsWith("W")) {
-        	String etag = savedETag.replaceFirst("(\"?)$", "-" + compressedContentEncoding + "$1");
+                String etag = savedETag.replaceFirst("(\"?)$", "-" + compressedContentEncoding + "$1");
                 httpResponse.setHeader(ETAG_HEADER, etag);
             } else {
                 httpResponse.setHeader(ETAG_HEADER, savedETag);
@@ -300,7 +301,7 @@ final class CompressingHttpServletResponse extends HttpServletResponseWrapper {
         if (compressing) {
             // do nothing -- caller-supplied content length is not meaningful
             LOGGER.debug(
-                "Ignoring application-specified content length since response is compressed");
+                    "Ignoring application-specified content length since response is compressed");
         } else {
             savedContentLength = contentLength;
             savedContentLengthSet = true;
@@ -339,8 +340,8 @@ final class CompressingHttpServletResponse extends HttpServletResponseWrapper {
     private void setCompressionResponseHeaders() {
         LOGGER.debug("Setting compression-related headers");
         String fullContentEncodingHeader = savedContentEncoding == null
-            ? compressedContentEncoding
-            : savedContentEncoding + ',' + compressedContentEncoding;
+                ? compressedContentEncoding
+                : savedContentEncoding + ',' + compressedContentEncoding;
         httpResponse.setHeader(CONTENT_ENCODING_HEADER, fullContentEncodingHeader);
         setETagHeader();
         if (context.isDebug()) {
@@ -430,10 +431,10 @@ final class CompressingHttpServletResponse extends HttpServletResponseWrapper {
     private CompressingServletOutputStream getCompressingServletOutputStream() throws IOException {
         if (compressingSOS == null) {
             compressingSOS =
-                new CompressingServletOutputStream(httpResponse.getOutputStream(),
-                    compressingStreamFactory,
-                    this,
-                    context);
+                    new CompressingServletOutputStream(httpResponse.getOutputStream(),
+                            compressingStreamFactory,
+                            this,
+                            context);
         }
 
         if (!compressingSOS.isClosed()) {
@@ -453,9 +454,9 @@ final class CompressingHttpServletResponse extends HttpServletResponseWrapper {
             return true;
         }
         if (savedContentLengthSet
-            && savedContentLength < (long) context.getCompressionThreshold()) {
+                && savedContentLength < (long) context.getCompressionThreshold()) {
             LOGGER.debug("Will not compress since page has set a content length which is less than "
-                + "the compression threshold: " + savedContentLength);
+                    + "the compression threshold: " + savedContentLength);
             return true;
         }
         if (noTransformSet) {

--- a/src/main/java/com/github/ziplet/filter/compression/CompressingServletInputStream.java
+++ b/src/main/java/com/github/ziplet/filter/compression/CompressingServletInputStream.java
@@ -15,9 +15,11 @@
  */
 package com.github.ziplet.filter.compression;
 
+import jakarta.servlet.ReadListener;
+import jakarta.servlet.ServletInputStream;
+
 import java.io.IOException;
 import java.io.InputStream;
-import javax.servlet.ServletInputStream;
 
 /**
  * <p>Implementation of {@link ServletInputStream} which will decompress data read from it.</p>
@@ -31,11 +33,11 @@ final class CompressingServletInputStream extends ServletInputStream {
     private boolean closed;
 
     CompressingServletInputStream(InputStream rawStream,
-        CompressingStreamFactory compressingStreamFactory,
-        CompressingFilterContext context) throws IOException {
+                                  CompressingStreamFactory compressingStreamFactory,
+                                  CompressingFilterContext context) throws IOException {
         this.compressingStream =
-            compressingStreamFactory.getCompressingStream(rawStream, context)
-                .getCompressingInputStream();
+                compressingStreamFactory.getCompressingStream(rawStream, context)
+                        .getCompressingInputStream();
     }
 
     @Override
@@ -104,5 +106,20 @@ final class CompressingServletInputStream extends ServletInputStream {
     @Override
     public String toString() {
         return "CompressingServletInputStream";
+    }
+
+    @Override
+    public boolean isFinished() {
+        return closed;
+    }
+
+    @Override
+    public boolean isReady() {
+        return true;
+    }
+
+    @Override
+    public void setReadListener(ReadListener readListener) {
+
     }
 }

--- a/src/main/java/com/github/ziplet/filter/compression/CompressingServletOutputStream.java
+++ b/src/main/java/com/github/ziplet/filter/compression/CompressingServletOutputStream.java
@@ -15,11 +15,13 @@
  */
 package com.github.ziplet.filter.compression;
 
-import java.io.IOException;
-import java.io.OutputStream;
-import javax.servlet.ServletOutputStream;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.WriteListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.OutputStream;
 
 /**
  * Implementation of {@link ServletOutputStream} which will optionally compress data written to it.
@@ -29,7 +31,7 @@ import org.slf4j.LoggerFactory;
 final class CompressingServletOutputStream extends ServletOutputStream {
 
     private static final Logger LOGGER = LoggerFactory
-        .getLogger(CompressingServletOutputStream.class);
+            .getLogger(CompressingServletOutputStream.class);
     private final OutputStream rawStream;
     private final CompressingStreamFactory compressingStreamFactory;
     private final CompressingHttpServletResponse compressingResponse;
@@ -39,9 +41,9 @@ final class CompressingServletOutputStream extends ServletOutputStream {
     private boolean aborted;
 
     CompressingServletOutputStream(OutputStream rawStream,
-        CompressingStreamFactory compressingStreamFactory,
-        CompressingHttpServletResponse compressingResponse,
-        CompressingFilterContext context) {
+                                   CompressingStreamFactory compressingStreamFactory,
+                                   CompressingHttpServletResponse compressingResponse,
+                                   CompressingFilterContext context) {
         this.rawStream = rawStream;
         this.compressingStreamFactory = compressingStreamFactory;
         this.compressingResponse = compressingResponse;
@@ -131,10 +133,10 @@ final class CompressingServletOutputStream extends ServletOutputStream {
     private void checkWriteState() {
         if (thresholdOutputStream == null) {
             thresholdOutputStream =
-                new ThresholdOutputStream(rawStream,
-                    compressingStreamFactory,
-                    context,
-                    new ResponseBufferCommitmentCallback(compressingResponse));
+                    new ThresholdOutputStream(rawStream,
+                            compressingStreamFactory,
+                            context,
+                            new ResponseBufferCommitmentCallback(compressingResponse));
         }
     }
 
@@ -144,8 +146,17 @@ final class CompressingServletOutputStream extends ServletOutputStream {
         }
     }
 
+    @Override
+    public boolean isReady() {
+        return true;
+    }
+
+    @Override
+    public void setWriteListener(WriteListener writeListener) {
+    }
+
     private static final class ResponseBufferCommitmentCallback
-        implements ThresholdOutputStream.BufferCommitmentCallback {
+            implements ThresholdOutputStream.BufferCommitmentCallback {
 
         private final CompressingHttpServletResponse response;
 

--- a/src/main/java/com/github/ziplet/filter/compression/CompressingStreamFactory.java
+++ b/src/main/java/com/github/ziplet/filter/compression/CompressingStreamFactory.java
@@ -16,6 +16,8 @@
 package com.github.ziplet.filter.compression;
 
 import com.github.ziplet.filter.compression.statistics.CompressingFilterStats;
+import jakarta.servlet.http.HttpServletRequest;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -34,7 +36,6 @@ import java.util.zip.GZIPOutputStream;
 import java.util.zip.InflaterInputStream;
 import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
-import javax.servlet.http.HttpServletRequest;
 
 /**
  * <p>Implementations of this abstract class can add compression of a particular type to a given
@@ -72,7 +73,7 @@ abstract class CompressingStreamFactory {
     private static final String COMPRESS_ENCODING = "compress";
     private static final String X_COMPRESS_ENCODING = "x-compress";
     static final String[] ALL_COMPRESSION_ENCODINGS = {
-        GZIP_ENCODING, DEFLATE_ENCODING, COMPRESS_ENCODING, X_GZIP_ENCODING, X_COMPRESS_ENCODING
+            GZIP_ENCODING, DEFLATE_ENCODING, COMPRESS_ENCODING, X_GZIP_ENCODING, X_COMPRESS_ENCODING
     };
     /**
      * "Any encoding" content type: the "*" wildcard.
@@ -87,7 +88,7 @@ abstract class CompressingStreamFactory {
      * {@link CompressingStreamFactory}.
      */
     private static final Map<String, String> bestEncodingCache =
-        Collections.synchronizedMap(new HashMap<String, String>(101));
+            Collections.synchronizedMap(new HashMap<String, String>(101));
     /**
      * Maps content type String to appropriate implementation of {@link CompressingStreamFactory}.
      */
@@ -107,7 +108,7 @@ abstract class CompressingStreamFactory {
 
     static {
         Map<String, CompressingStreamFactory> temp = new HashMap<String, CompressingStreamFactory>(
-            11);
+                11);
         temp.put(GZIP_ENCODING, GZIP_CSF);
         temp.put(X_GZIP_ENCODING, GZIP_CSF);
         temp.put(COMPRESS_ENCODING, ZIP_CSF);
@@ -117,8 +118,8 @@ abstract class CompressingStreamFactory {
     }
 
     private static OutputStream maybeWrapStatsOutputStream(OutputStream outputStream,
-        CompressingFilterContext context,
-        StatsField field) {
+                                                           CompressingFilterContext context,
+                                                           StatsField field) {
         assert outputStream != null;
         OutputStream result;
         CompressingFilterStats stats = context.getStats();
@@ -127,8 +128,8 @@ abstract class CompressingStreamFactory {
     }
 
     private static InputStream maybeWrapStatsInputStream(InputStream inputStream,
-        CompressingFilterContext context,
-        StatsField field) {
+                                                         CompressingFilterContext context,
+                                                         StatsField field) {
         assert inputStream != null;
         InputStream result;
         CompressingFilterStats stats = context.getStats();
@@ -165,7 +166,7 @@ abstract class CompressingStreamFactory {
     static String getBestContentEncoding(HttpServletRequest httpRequest) {
 
         String forcedEncoding = (String) httpRequest
-            .getAttribute(CompressingFilter.FORCE_ENCODING_KEY);
+                .getAttribute(CompressingFilter.FORCE_ENCODING_KEY);
         String bestEncoding;
         if (forcedEncoding != null) {
 
@@ -174,7 +175,7 @@ abstract class CompressingStreamFactory {
         } else {
 
             String acceptEncodingHeader = httpRequest.getHeader(
-                CompressingHttpServletResponse.ACCEPT_ENCODING_HEADER);
+                    CompressingHttpServletResponse.ACCEPT_ENCODING_HEADER);
             if (acceptEncodingHeader == null) {
 
                 bestEncoding = NO_ENCODING;
@@ -302,10 +303,10 @@ abstract class CompressingStreamFactory {
     }
 
     abstract CompressingOutputStream getCompressingStream(OutputStream servletOutputStream,
-        CompressingFilterContext context) throws IOException;
+                                                          CompressingFilterContext context) throws IOException;
 
     abstract CompressingInputStream getCompressingStream(InputStream servletInputStream,
-        CompressingFilterContext context) throws IOException;
+                                                         CompressingFilterContext context) throws IOException;
 
     private static final class ContentEncodingQ {
 
@@ -336,16 +337,16 @@ abstract class CompressingStreamFactory {
 
         @Override
         CompressingOutputStream getCompressingStream(final OutputStream outputStream,
-            final CompressingFilterContext context) throws IOException {
+                                                     final CompressingFilterContext context) throws IOException {
             return new CompressingOutputStream() {
                 private final DeflaterOutputStream gzipOutputStream =
-                    new LevelGZIPOutputStream(
-                        CompressingStreamFactory.maybeWrapStatsOutputStream(
-                            outputStream, context, StatsField.RESPONSE_COMPRESSED_BYTES),
-                        context.getCompressionLevel());
+                        new LevelGZIPOutputStream(
+                                CompressingStreamFactory.maybeWrapStatsOutputStream(
+                                        outputStream, context, StatsField.RESPONSE_COMPRESSED_BYTES),
+                                context.getCompressionLevel());
                 private final OutputStream statsOutputStream =
-                    CompressingStreamFactory.maybeWrapStatsOutputStream(
-                        gzipOutputStream, context, StatsField.RESPONSE_INPUT_BYTES);
+                        CompressingStreamFactory.maybeWrapStatsOutputStream(
+                                gzipOutputStream, context, StatsField.RESPONSE_INPUT_BYTES);
 
                 public OutputStream getCompressingOutputStream() {
                     return statsOutputStream;
@@ -359,15 +360,15 @@ abstract class CompressingStreamFactory {
 
         @Override
         CompressingInputStream getCompressingStream(final InputStream inputStream,
-            final CompressingFilterContext context) {
+                                                    final CompressingFilterContext context) {
             return new CompressingInputStream() {
                 public InputStream getCompressingInputStream() throws IOException {
                     return CompressingStreamFactory.maybeWrapStatsInputStream(
-                        new GZIPInputStream(
-                            CompressingStreamFactory.maybeWrapStatsInputStream(
-                                inputStream, context, StatsField.REQUEST_COMPRESSED_BYTES)),
-                        context,
-                        StatsField.REQUEST_INPUT_BYTES);
+                            new GZIPInputStream(
+                                    CompressingStreamFactory.maybeWrapStatsInputStream(
+                                            inputStream, context, StatsField.REQUEST_COMPRESSED_BYTES)),
+                            context,
+                            StatsField.REQUEST_INPUT_BYTES);
                 }
             };
         }
@@ -375,7 +376,7 @@ abstract class CompressingStreamFactory {
         private static class LevelGZIPOutputStream extends GZIPOutputStream {
 
             public LevelGZIPOutputStream(OutputStream out, int compressionLevel)
-                throws IOException {
+                    throws IOException {
                 super(out);
                 def.setLevel(compressionLevel);
             }
@@ -386,15 +387,15 @@ abstract class CompressingStreamFactory {
 
         @Override
         CompressingOutputStream getCompressingStream(final OutputStream outputStream,
-            final CompressingFilterContext context) {
+                                                     final CompressingFilterContext context) {
             return new CompressingOutputStream() {
                 private final DeflaterOutputStream zipOutputStream =
-                    new ZipOutputStream(
-                        CompressingStreamFactory.maybeWrapStatsOutputStream(
-                            outputStream, context, StatsField.RESPONSE_COMPRESSED_BYTES));
+                        new ZipOutputStream(
+                                CompressingStreamFactory.maybeWrapStatsOutputStream(
+                                        outputStream, context, StatsField.RESPONSE_COMPRESSED_BYTES));
                 private final OutputStream statsOutputStream =
-                    CompressingStreamFactory.maybeWrapStatsOutputStream(
-                        zipOutputStream, context, StatsField.RESPONSE_INPUT_BYTES);
+                        CompressingStreamFactory.maybeWrapStatsOutputStream(
+                                zipOutputStream, context, StatsField.RESPONSE_INPUT_BYTES);
 
                 public OutputStream getCompressingOutputStream() {
                     return statsOutputStream;
@@ -408,15 +409,15 @@ abstract class CompressingStreamFactory {
 
         @Override
         CompressingInputStream getCompressingStream(final InputStream inputStream,
-            final CompressingFilterContext context) {
+                                                    final CompressingFilterContext context) {
             return new CompressingInputStream() {
                 public InputStream getCompressingInputStream() {
                     return CompressingStreamFactory.maybeWrapStatsInputStream(
-                        new ZipInputStream(
-                            CompressingStreamFactory.maybeWrapStatsInputStream(
-                                inputStream, context, StatsField.REQUEST_COMPRESSED_BYTES)),
-                        context,
-                        StatsField.REQUEST_INPUT_BYTES);
+                            new ZipInputStream(
+                                    CompressingStreamFactory.maybeWrapStatsInputStream(
+                                            inputStream, context, StatsField.REQUEST_COMPRESSED_BYTES)),
+                            context,
+                            StatsField.REQUEST_INPUT_BYTES);
                 }
             };
         }
@@ -426,16 +427,16 @@ abstract class CompressingStreamFactory {
 
         @Override
         CompressingOutputStream getCompressingStream(final OutputStream outputStream,
-            final CompressingFilterContext context) {
+                                                     final CompressingFilterContext context) {
             return new CompressingOutputStream() {
                 private final DeflaterOutputStream deflaterOutputStream =
-                    new DeflaterOutputStream(
-                        CompressingStreamFactory.maybeWrapStatsOutputStream(
-                            outputStream, context, StatsField.RESPONSE_COMPRESSED_BYTES),
-                        new Deflater(context.getCompressionLevel()));
+                        new DeflaterOutputStream(
+                                CompressingStreamFactory.maybeWrapStatsOutputStream(
+                                        outputStream, context, StatsField.RESPONSE_COMPRESSED_BYTES),
+                                new Deflater(context.getCompressionLevel()));
                 private final OutputStream statsOutputStream =
-                    CompressingStreamFactory.maybeWrapStatsOutputStream(
-                        deflaterOutputStream, context, StatsField.RESPONSE_INPUT_BYTES);
+                        CompressingStreamFactory.maybeWrapStatsOutputStream(
+                                deflaterOutputStream, context, StatsField.RESPONSE_INPUT_BYTES);
 
                 public OutputStream getCompressingOutputStream() {
                     return statsOutputStream;
@@ -449,15 +450,15 @@ abstract class CompressingStreamFactory {
 
         @Override
         CompressingInputStream getCompressingStream(final InputStream inputStream,
-            final CompressingFilterContext context) {
+                                                    final CompressingFilterContext context) {
             return new CompressingInputStream() {
                 public InputStream getCompressingInputStream() {
                     return CompressingStreamFactory.maybeWrapStatsInputStream(
-                        new InflaterInputStream(
-                            CompressingStreamFactory.maybeWrapStatsInputStream(
-                                inputStream, context, StatsField.REQUEST_COMPRESSED_BYTES)),
-                        context,
-                        StatsField.REQUEST_INPUT_BYTES);
+                            new InflaterInputStream(
+                                    CompressingStreamFactory.maybeWrapStatsInputStream(
+                                            inputStream, context, StatsField.REQUEST_COMPRESSED_BYTES)),
+                            context,
+                            StatsField.REQUEST_INPUT_BYTES);
                 }
             };
         }

--- a/src/main/java/com/github/ziplet/filter/compression/EmptyEnumeration.java
+++ b/src/main/java/com/github/ziplet/filter/compression/EmptyEnumeration.java
@@ -24,7 +24,7 @@ import java.util.NoSuchElementException;
  * @author Sean Owen
  * @since 1.6
  */
-final class EmptyEnumeration implements Enumeration<Object> {
+final class EmptyEnumeration implements Enumeration {
 
     private static final Enumeration<?> instance = new EmptyEnumeration();
 

--- a/src/main/java/com/github/ziplet/filter/compression/InputStatsCallback.java
+++ b/src/main/java/com/github/ziplet/filter/compression/InputStatsCallback.java
@@ -1,6 +1,7 @@
 package com.github.ziplet.filter.compression;
 
 import com.github.ziplet.filter.compression.statistics.CompressingFilterStats;
+
 import java.io.Serializable;
 
 /**

--- a/src/main/java/com/github/ziplet/filter/compression/IteratorEnumeration.java
+++ b/src/main/java/com/github/ziplet/filter/compression/IteratorEnumeration.java
@@ -24,7 +24,7 @@ import java.util.Iterator;
  * @author Sean Owen
  * @since 1.6
  */
-final class IteratorEnumeration implements Enumeration<Object> {
+final class IteratorEnumeration implements Enumeration {
 
     private final Iterator<?> iterator;
 

--- a/src/main/java/com/github/ziplet/filter/compression/OutputStatsCallback.java
+++ b/src/main/java/com/github/ziplet/filter/compression/OutputStatsCallback.java
@@ -1,6 +1,7 @@
 package com.github.ziplet.filter.compression;
 
 import com.github.ziplet.filter.compression.statistics.CompressingFilterStats;
+
 import java.io.Serializable;
 
 /**

--- a/src/main/java/com/github/ziplet/filter/compression/StatsInputStream.java
+++ b/src/main/java/com/github/ziplet/filter/compression/StatsInputStream.java
@@ -16,6 +16,7 @@
 package com.github.ziplet.filter.compression;
 
 import com.github.ziplet.filter.compression.statistics.CompressingFilterStats;
+
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -35,7 +36,7 @@ public class StatsInputStream extends InputStream {
     protected final StatsField field;
 
     public StatsInputStream(InputStream inputStream, CompressingFilterStats stats,
-        StatsField field) {
+                            StatsField field) {
         assert inputStream != null && stats != null;
         this.inputStream = inputStream;
         this.stats = stats;

--- a/src/main/java/com/github/ziplet/filter/compression/StatsOutputStream.java
+++ b/src/main/java/com/github/ziplet/filter/compression/StatsOutputStream.java
@@ -16,6 +16,7 @@
 package com.github.ziplet.filter.compression;
 
 import com.github.ziplet.filter.compression.statistics.CompressingFilterStats;
+
 import java.io.IOException;
 import java.io.OutputStream;
 

--- a/src/main/java/com/github/ziplet/filter/compression/ThresholdOutputStream.java
+++ b/src/main/java/com/github/ziplet/filter/compression/ThresholdOutputStream.java
@@ -15,11 +15,12 @@
  */
 package com.github.ziplet.filter.compression;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * @author Sean Owen
@@ -40,11 +41,11 @@ final class ThresholdOutputStream extends OutputStream {
     private boolean forceOut1;
 
     ThresholdOutputStream(OutputStream out1,
-        CompressingStreamFactory compressingStreamFactory,
-        CompressingFilterContext context,
-        BufferCommitmentCallback thresholdReachedCallback) {
+                          CompressingStreamFactory compressingStreamFactory,
+                          CompressingFilterContext context,
+                          BufferCommitmentCallback thresholdReachedCallback) {
         assert out1 != null && compressingStreamFactory != null
-            && context != null && thresholdReachedCallback != null;
+                && context != null && thresholdReachedCallback != null;
         buffering = true;
         this.out1 = out1;
         this.compressingStreamFactory = compressingStreamFactory;

--- a/src/main/java/com/github/ziplet/filter/compression/statistics/CompressingFilterStatsImpl.java
+++ b/src/main/java/com/github/ziplet/filter/compression/statistics/CompressingFilterStatsImpl.java
@@ -36,7 +36,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * @since 1.1
  */
 public class CompressingFilterStatsImpl implements Serializable,
-    com.github.ziplet.filter.compression.statistics.CompressingFilterStats {
+        com.github.ziplet.filter.compression.statistics.CompressingFilterStats {
 
     private static final long serialVersionUID = -2246829834191152845L;
     /**
@@ -155,7 +155,7 @@ public class CompressingFilterStatsImpl implements Serializable,
      */
     public double getResponseAverageCompressionRatio() {
         return getResponseCompressedBytes() == 0L ? 0.0 :
-            (double) getResponseInputBytes() / (double) getResponseCompressedBytes();
+                (double) getResponseInputBytes() / (double) getResponseCompressedBytes();
     }
 
     /**
@@ -213,7 +213,7 @@ public class CompressingFilterStatsImpl implements Serializable,
      */
     public double getRequestAverageCompressionRatio() {
         return requestCompressedBytes.get() == 0L ? 0.0 :
-            (double) requestInputBytes.get() / (double) requestCompressedBytes.get();
+                (double) requestInputBytes.get() / (double) requestCompressedBytes.get();
     }
 
     /**
@@ -222,9 +222,9 @@ public class CompressingFilterStatsImpl implements Serializable,
     @Override
     public String toString() {
         return "CompressingFilterStatsImpl[responses compressed: " + numResponsesCompressed
-            + ", avg. response compression ratio: " + getResponseAverageCompressionRatio()
-            + ", requests compressed: " + numRequestsCompressed
-            + ", avg. request compression ratio: " + getRequestAverageCompressionRatio() + ']';
+                + ", avg. response compression ratio: " + getResponseAverageCompressionRatio()
+                + ", requests compressed: " + numRequestsCompressed
+                + ", avg. request compression ratio: " + getRequestAverageCompressionRatio() + ']';
     }
 
     @Override

--- a/src/main/resources/license-mappings.xml
+++ b/src/main/resources/license-mappings.xml
@@ -1,70 +1,70 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <license-lookup xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns="https://source.jasig.org/schemas/maven-notice-plugin/license-lookup"
-    xsi:schemaLocation="https://source.jasig.org/schemas/maven-notice-plugin/license-lookup https://source.jasig.org/schemas/maven-notice-plugin/license-lookup/license-lookup-v1.0.xsd">
+                xmlns="https://source.jasig.org/schemas/maven-notice-plugin/license-lookup"
+                xsi:schemaLocation="https://source.jasig.org/schemas/maven-notice-plugin/license-lookup https://source.jasig.org/schemas/maven-notice-plugin/license-lookup/license-lookup-v1.0.xsd">
 
-    <!-- https://commons.apache.org/proper/commons-bcel/ -->
-    <artifact>
-        <groupId>bcel</groupId>
-        <artifactId>bcel</artifactId>
-        <version>5.1</version>
-        <license>The Apache Software License, Version 2.0</license>
-    </artifact>
+  <!-- https://commons.apache.org/proper/commons-bcel/ -->
+  <artifact>
+    <groupId>bcel</groupId>
+    <artifactId>bcel</artifactId>
+    <version>5.1</version>
+    <license>The Apache Software License, Version 2.0</license>
+  </artifact>
 
-    <!-- http://attic.apache.org/projects/jakarta-regexp.html -->
-    <artifact>
-        <groupId>jakarta-regexp</groupId>
-        <artifactId>jakarta-regexp</artifactId>
-        <version>1.4</version>
-        <license>The Apache Software License, Version 2.0</license>
-    </artifact>
-    <artifact>
-        <groupId>regexp</groupId>
-        <artifactId>regexp</artifactId>
-        <version>1.2</version>
-        <license>The Apache Software License, Version 2.0</license>
-    </artifact>
+  <!-- http://attic.apache.org/projects/jakarta-regexp.html -->
+  <artifact>
+    <groupId>jakarta-regexp</groupId>
+    <artifactId>jakarta-regexp</artifactId>
+    <version>1.4</version>
+    <license>The Apache Software License, Version 2.0</license>
+  </artifact>
+  <artifact>
+    <groupId>regexp</groupId>
+    <artifactId>regexp</artifactId>
+    <version>1.2</version>
+    <license>The Apache Software License, Version 2.0</license>
+  </artifact>
 
-    <!-- http://stackoverflow.com/questions/16343572/license-for-glassfish-javax-servlet-servlet-api-version-2-5 -->
-    <!-- https://glassfish.java.net/nonav/public/CDDL+GPL.html -->
-    <artifact>
-        <groupId>javax.servlet</groupId>
-        <artifactId>servlet-api</artifactId>
-        <version>2.5</version>
-        <license>CDDL 1.1 or GPL2 w/ CPE</license>
-    </artifact>
+  <!-- http://stackoverflow.com/questions/16343572/license-for-glassfish-javax-servlet-servlet-api-version-2-5 -->
+  <!-- https://glassfish.java.net/nonav/public/CDDL+GPL.html -->
+  <artifact>
+    <groupId>jakarta.servlet</groupId>
+    <artifactId>servlet-api</artifactId>
+    <version>2.5</version>
+    <license>CDDL 1.1 or GPL2 w/ CPE</license>
+  </artifact>
 
-    <!-- http://www.jdom.org/docs/faq.html#a0030 -->
-    <artifact>
-        <groupId>jdom</groupId>
-        <artifactId>jdom</artifactId>
-        <version>1.0</version>
-        <license>JDOM license (Apache style),
-            https://github.com/hunterhacker/jdom/blob/master/LICENSE.txt
-        </license>
-    </artifact>
+  <!-- http://www.jdom.org/docs/faq.html#a0030 -->
+  <artifact>
+    <groupId>jdom</groupId>
+    <artifactId>jdom</artifactId>
+    <version>1.0</version>
+    <license>JDOM license (Apache style),
+      https://github.com/hunterhacker/jdom/blob/master/LICENSE.txt
+    </license>
+  </artifact>
 
-    <!-- http://nekohtml.sourceforge.net/ -->
-    <artifact>
-        <groupId>nekohtml</groupId>
-        <artifactId>nekohtml</artifactId>
-        <version>0.9.5</version>
-        <license>The Apache Software License, Version 2.0</license>
-    </artifact>
+  <!-- http://nekohtml.sourceforge.net/ -->
+  <artifact>
+    <groupId>nekohtml</groupId>
+    <artifactId>nekohtml</artifactId>
+    <version>0.9.5</version>
+    <license>The Apache Software License, Version 2.0</license>
+  </artifact>
 
-    <!-- http://attic.apache.org/projects/jakarta-oro.html -->
-    <artifact>
-        <groupId>oro</groupId>
-        <artifactId>oro</artifactId>
-        <version>2.0.8</version>
-        <license>The Apache Software License, Version 1.1</license>
-    </artifact>
+  <!-- http://attic.apache.org/projects/jakarta-oro.html -->
+  <artifact>
+    <groupId>oro</groupId>
+    <artifactId>oro</artifactId>
+    <version>2.0.8</version>
+    <license>The Apache Software License, Version 1.1</license>
+  </artifact>
 
-    <!-- http://xerces.apache.org/ -->
-    <artifact>
-        <groupId>xerces</groupId>
-        <artifactId>xercesImpl</artifactId>
-        <version>2.4.0</version>
-        <license>The Apache Software License, Version 2.0</license>
-    </artifact>
+  <!-- http://xerces.apache.org/ -->
+  <artifact>
+    <groupId>xerces</groupId>
+    <artifactId>xercesImpl</artifactId>
+    <version>2.4.0</version>
+    <license>The Apache Software License, Version 2.0</license>
+  </artifact>
 </license-lookup>

--- a/src/test/java/com/github/ziplet/filter/compression/HttpTestServlet.java
+++ b/src/test/java/com/github/ziplet/filter/compression/HttpTestServlet.java
@@ -1,0 +1,16 @@
+package com.github.ziplet.filter.compression;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+public class HttpTestServlet extends HttpServlet {
+
+    @Override
+    public void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        super.doGet(req, resp);
+    }
+}

--- a/src/test/java/com/github/ziplet/filter/compression/StatsInputStreamTest.java
+++ b/src/test/java/com/github/ziplet/filter/compression/StatsInputStreamTest.java
@@ -17,9 +17,10 @@ package com.github.ziplet.filter.compression;
 
 import com.github.ziplet.filter.compression.statistics.CompressingFilterStats;
 import com.github.ziplet.filter.compression.statistics.CompressingFilterStatsImpl;
+import junit.framework.TestCase;
+
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-import junit.framework.TestCase;
 
 /**
  * Tests {@link StatsInputStream}.
@@ -37,7 +38,7 @@ public final class StatsInputStreamTest extends TestCase {
         super.setUp();
         bais = new ByteArrayInputStream(new byte[100]);
         statsIn = new MockStatsInputStream(bais, new CompressingFilterStatsImpl(),
-            StatsField.REQUEST_INPUT_BYTES);
+                StatsField.REQUEST_INPUT_BYTES);
     }
 
     public void testStats() throws Exception {
@@ -53,7 +54,7 @@ public final class StatsInputStreamTest extends TestCase {
     private static final class MockStatsInputStream extends StatsInputStream {
 
         public MockStatsInputStream(InputStream inputStream, CompressingFilterStats stats,
-            StatsField field) {
+                                    StatsField field) {
             super(inputStream, stats, field);
         }
 

--- a/src/test/java/com/github/ziplet/filter/compression/StatsOutputStreamTest.java
+++ b/src/test/java/com/github/ziplet/filter/compression/StatsOutputStreamTest.java
@@ -17,9 +17,10 @@ package com.github.ziplet.filter.compression;
 
 import com.github.ziplet.filter.compression.statistics.CompressingFilterStats;
 import com.github.ziplet.filter.compression.statistics.CompressingFilterStatsImpl;
+import junit.framework.TestCase;
+
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
-import junit.framework.TestCase;
 
 /**
  * Tests {@link StatsOutputStream}.
@@ -36,7 +37,7 @@ public final class StatsOutputStreamTest extends TestCase {
         super.setUp();
         baos = new ByteArrayOutputStream();
         statsOut = new MockStatsOutputStream(baos, new CompressingFilterStatsImpl(),
-            StatsField.RESPONSE_INPUT_BYTES);
+                StatsField.RESPONSE_INPUT_BYTES);
     }
 
     public void testStats() throws Exception {
@@ -61,7 +62,7 @@ public final class StatsOutputStreamTest extends TestCase {
     private static final class MockStatsOutputStream extends StatsOutputStream {
 
         public MockStatsOutputStream(OutputStream outputStream, CompressingFilterStats stats,
-            StatsField field) {
+                                     StatsField field) {
             super(outputStream, stats, field);
         }
 

--- a/src/test/java/com/github/ziplet/filter/compression/ThresholdOutputStreamTest.java
+++ b/src/test/java/com/github/ziplet/filter/compression/ThresholdOutputStreamTest.java
@@ -15,11 +15,12 @@
  */
 package com.github.ziplet.filter.compression;
 
-import com.mockrunner.mock.web.WebMockObjectFactory;
+import jakarta.servlet.FilterConfig;
+import junit.framework.TestCase;
+import org.springframework.mock.web.MockFilterConfig;
+
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
-import javax.servlet.FilterConfig;
-import junit.framework.TestCase;
 
 /**
  * Tests {@link CompressingFilter}.
@@ -32,18 +33,18 @@ public final class ThresholdOutputStreamTest extends TestCase {
     private Callback callback;
     private ThresholdOutputStream tos;
 
+    FilterConfig filterConfig = new MockFilterConfig();
+
     @Override
     public void setUp() throws Exception {
         super.setUp();
         baos = new ByteArrayOutputStream();
         callback = new Callback();
-        WebMockObjectFactory factory = new WebMockObjectFactory();
-        FilterConfig filterConfig = factory.getMockFilterConfig();
         CompressingFilterContext context = new CompressingFilterContext(filterConfig);
         tos = new ThresholdOutputStream(baos,
-            CompressingStreamFactory.getFactoryForContentEncoding("gzip"),
-            context,
-            callback);
+                CompressingStreamFactory.getFactoryForContentEncoding("gzip"),
+                context,
+                callback);
     }
 
     public void testWriteFlush() throws Exception {


### PR DESCRIPTION
The conversion was done automatically by IntelliJ.

The migration required also replacing com.mockrunner:mockrunner-servlet library with org.springframework:spring-test one, because the old library still operated on javax packages. The latest version of Spring requires Java17 to be present, however the library still targets Java1.8.